### PR TITLE
[Dy2St][CINN] Replace `build_strategy` with `backend` option

### DIFF
--- a/modulus/sym/domain/constraint/constraint.py
+++ b/modulus/sym/domain/constraint/constraint.py
@@ -107,10 +107,8 @@ class Constraint:
         if jit_manager.enabled:
             from paddle import jit
             from paddle import static
-            build_strategy = static.BuildStrategy()
-            build_strategy.build_cinn_pass = jit_manager.use_cinn
             self.model.forward = jit.to_static(
-                build_strategy=build_strategy,
+                backend="CINN",
                 full_graph=True,
             )(self.model.forward)
 

--- a/modulus/sym/domain/constraint/constraint.py
+++ b/modulus/sym/domain/constraint/constraint.py
@@ -106,9 +106,9 @@ class Constraint:
         jit_manager = JitManager()
         if jit_manager.enabled:
             from paddle import jit
-            from paddle import static
+            backend = "CINN" if jit_manager.use_cinn else None
             self.model.forward = jit.to_static(
-                backend="CINN",
+                backend=backend,
                 full_graph=True,
             )(self.model.forward)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Follow PaddlePaddle/Paddle#71815，弃用 `build_strategy.build_cinn_pass`，采用更加易于使用的 `backend`，以确保后续 CINN 推为默认后提供给用户更加友好的接口

@HydrogenSulfate

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->

