### PR TITLE
[Dy2St][CINN] Use CINN as default JIT backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ cd ./examples/ldc/
 python ldc_2d.py
 
 # run on dy2st mode
-python ldc_2d.py jit=true
+python ldc_2d.py jit=true jit_use_cinn=false
 
 # run on cinn mode(i.e. compiled mode, recommended for performance)
-python ldc_2d.py jit=true jit_use_cinn=true
+python ldc_2d.py jit=true
 ```
 
 ## Contributing

--- a/modulus/sym/hydra/config.py
+++ b/modulus/sym/hydra/config.py
@@ -51,7 +51,7 @@ class ModulusConfig:
     summary_histograms: bool = False
     jit: bool = False
     jit_use_prim: bool = False
-    jit_use_cinn: bool = False
+    jit_use_cinn: bool = True
     jit_arch_mode: str = "only_activation"
     jit_autograd_nodes: bool = False
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

将 modulus 默认 JIT backend 修改为 `CINN`

- 仅动转静可参考 `python ldc_2d.py jit=true jit_use_cinn=false`
- 动转静+CINN 可参考 `python ldc_2d.py jit=true`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus-sym/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus-sym/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus-sym/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->